### PR TITLE
Fixes the gatus checks on internal dns requests

### DIFF
--- a/kubernetes/templates/gatus/internal/configmap.yaml
+++ b/kubernetes/templates/gatus/internal/configmap.yaml
@@ -10,7 +10,7 @@ data:
     endpoints:
       - name: "${APP}"
         group: internal
-        url: 1.1.1.1
+        url: ${PIHOLE_LOCAL_DNS_IP}
         interval: 1m
         ui:
           hide-hostname: true


### PR DESCRIPTION
Use the pihole dns address for internal endpoints

Closes #95
