### PR TITLE
fix: add v6 support for extenal-dns pihole

### DIFF
--- a/kubernetes/apps/networking/external-dns/pihole/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/pihole/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
                 name: external-dns-pihole-secret
                 key: pihole-server
           - name: LOG_LEVEL
-            value: *logLevel
+            value: info
         livenessProbe:
           httpGet:
             path: /healthz

--- a/kubernetes/apps/networking/external-dns/pihole/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/pihole/app/helmrelease.yaml
@@ -28,18 +28,37 @@ spec:
     sources: ["service", "ingress"]
     registry: noop
     policy: upsert-only
-    provider: pihole
-    env:
-      - name: EXTERNAL_DNS_PIHOLE_SERVER
-        valueFrom:
-          secretKeyRef:
-            name: external-dns-pihole-secret
-            key: pihole-server
-      - name: EXTERNAL_DNS_PIHOLE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: external-dns-pihole-secret
-            key: pihole-password
+    provider:
+      name: webhook
+      webhook:
+        image:
+          repository: ghcr.io/tarantini-io/external-dns-pihole-webhook
+          tag: v1.0.0
+        env:
+          - name: PIHOLE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: external-dns-pihole-secret
+                key: external-dns-pihole-secret
+          - name: PIHOLE_SERVER
+            valueFrom:
+              secretKeyRef:
+                name: external-dns-pihole-secret
+                key: pihole-server
+          - name: LOG_LEVEL
+            value: *logLevel
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: http-webhook
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
     extraArgs:
       - --ingress-class=internal
     serviceMonitor:


### PR DESCRIPTION
Adds support to external-dns for v6 pihole through a webhook