### PR TITLE
Move all external-secrets to the v1 api

### DIFF
--- a/kubernetes/apps/auth/authelia/app/externalsecret.yaml
+++ b/kubernetes/apps/auth/authelia/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: authelia

--- a/kubernetes/apps/auth/glauth/app/externalsecret.yaml
+++ b/kubernetes/apps/auth/glauth/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: glauth

--- a/kubernetes/apps/cert-manager/cert-manager/issuers/externalsecret.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cert-manager-secret

--- a/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/linkwarden-cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/linkwarden-cluster/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: linkwarden-cnpg

--- a/kubernetes/apps/default/smtp-relay/app/externalsecret.yaml
+++ b/kubernetes/apps/default/smtp-relay/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: smtp-relay

--- a/kubernetes/apps/flux-system/addons/webhooks/github/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/addons/webhooks/github/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: github-webhook-token-secret

--- a/kubernetes/apps/kube-system/external-secrets/stores/onepassword/clustersecretstore.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/stores/onepassword/clustersecretstore.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/clustersecretstore_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: onepassword-connect

--- a/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: headlamp

--- a/kubernetes/apps/kube-system/synology-csi/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/synology-csi/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: synology-csi-client-info-secret

--- a/kubernetes/apps/monitoring/gatus-external-services/services/dns-backup/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/gatus-external-services/services/dns-backup/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: gatus-dns-backup-config

--- a/kubernetes/apps/monitoring/gatus-external-services/services/dns/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/gatus-external-services/services/dns/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: gatus-dns-config

--- a/kubernetes/apps/monitoring/gatus-external-services/services/gateway/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/gatus-external-services/services/gateway/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: gatus-gateway-config

--- a/kubernetes/apps/monitoring/gatus-external-services/services/nas/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/gatus-external-services/services/nas/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: gatus-nas-config

--- a/kubernetes/apps/monitoring/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: gatus

--- a/kubernetes/apps/monitoring/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: grafana

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: thanos-objstore-secret
@@ -25,7 +25,7 @@ spec:
         key: thanos
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: alertmanager

--- a/kubernetes/apps/monitoring/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/snmp-exporter/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: snmp

--- a/kubernetes/apps/monitoring/unpoller/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: unpoller

--- a/kubernetes/apps/networking/cloudflared/app/externalsecret.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name:  cloudflared-secret

--- a/kubernetes/apps/networking/external-dns/cloudflare/app/externalsecret.yaml
+++ b/kubernetes/apps/networking/external-dns/cloudflare/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: external-dns-cloudflare-secret

--- a/kubernetes/apps/networking/external-dns/pihole/app/externalsecret.yaml
+++ b/kubernetes/apps/networking/external-dns/pihole/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: external-dns-pihole-secret

--- a/kubernetes/apps/networking/orbital-sync/app/externalsecret.yaml
+++ b/kubernetes/apps/networking/orbital-sync/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: orbital-sync

--- a/kubernetes/apps/networking/pihole/app/externalsecret.yaml
+++ b/kubernetes/apps/networking/pihole/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: pihole-secret

--- a/kubernetes/apps/services/atuin/app/externalsecret.yaml
+++ b/kubernetes/apps/services/atuin/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: atuin

--- a/kubernetes/apps/services/coder/app/externalsecret.yaml
+++ b/kubernetes/apps/services/coder/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: coder

--- a/kubernetes/apps/services/linkwarden/app/externalsecret.yaml
+++ b/kubernetes/apps/services/linkwarden/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: linkwarden

--- a/kubernetes/apps/storage/minio/app/externalsecret.yaml
+++ b/kubernetes/apps/storage/minio/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.devbu.io/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: minio


### PR DESCRIPTION
Ensures external-secrets v0.17.0 won't break