### PR TITLE
fix: disable grafana securityContext capabilities to fix perm error on chown

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -290,6 +290,9 @@ spec:
         enabled: true
         searchNamespace: ALL
         labelValue: ""
+    initChownData:
+      securityContext:
+        capabilities: {}
     plugins:
       - grafana-clock-panel
       - grafana-piechart-panel


### PR DESCRIPTION
resolves an error where the init-chown-data container didn't have permission to chown